### PR TITLE
added a script to merge CMAQ fields for pm25 and ozone

### DIFF
--- a/spark/src/main/python/merge_cmaq_fields.py
+++ b/spark/src/main/python/merge_cmaq_fields.py
@@ -1,0 +1,26 @@
+import argparse
+import pandas as pd
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Process arguments.')
+    parser.add_argument('--input_file1', type=str,
+                        default='/projects/datatrans/groupe/updates2023/cmaq/2017/2017_pm25_daily_average.txt',
+                        help='the first input file')
+    parser.add_argument('--input_file2', type=str,
+                        default='/projects/datatrans/groupe/updates2023/cmaq/2017/2017_ozone_daily_8hour_maximum.txt',
+                        help='the second input file')
+    parser.add_argument('--output_file', type=str,
+                        default='/projects/ebcr/cmaq/2017/merged_cmaq_2017.csv',
+                        help='the output file with merged columns from the two input files')
+
+    args = parser.parse_args()
+    input_file1 = args.input_file1
+    input_file2 = args.input_file2
+    output_file = args.output_file
+
+    df1 = pd.read_csv(input_file1)
+    df2 = pd.read_csv(input_file2)
+
+    df = pd.merge(df1, df2, on=['FIPS', 'Date', 'Longitude', 'Latitude'], how="outer")
+    df.to_csv(output_file, index=False)

--- a/spark/src/main/python/merge_env.py
+++ b/spark/src/main/python/merge_env.py
@@ -1,6 +1,6 @@
 import pandas as pd
-import sys
 import os
+
 
 def load_file(filename):
     path = f"formatted/{filename}"


### PR DESCRIPTION
@jjgarciac @karafecho This PR is to add the script to merge CMAQ fields for pm25 and ozone to generate the environment cmaq input file to feed to FHIR PIT for data integration. @karafecho has already verified the FHIR PIT output with updated exposure data which used this new script to generate the updated input cmaq file, so the script has been verified through the updated FHIR PIT output with updated exposure data. I just need an approval from one of you so that I can get the PR merged. Thanks.